### PR TITLE
docs: fix simple typo, placeement -> placement

### DIFF
--- a/wm.c
+++ b/wm.c
@@ -1516,7 +1516,7 @@ client_place(struct client *c)
     y_off = m_list[mon].y / PLACE_RES;
 
     // If this is the first window in the workspace, we can simply center
-    // it. Also center it if the user wants to disable smart placeement.
+    // it. Also center it if the user wants to disable smart placement.
     if (f_list[curr_ws]->next == NULL || !conf.smart_place) {
         client_center(c);
         return;


### PR DESCRIPTION
There is a small typo in wm.c.

Should read `placement` rather than `placeement`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md