### PR TITLE
Fix fullscreen configure notify behavior

### DIFF
--- a/wm.c
+++ b/wm.c
@@ -789,6 +789,9 @@ handle_configure_request(XEvent *e)
     c = get_client_from_window(ev->window);
 
     if (c != NULL) {
+        if (c->fullscreen)
+            return;
+
         client_move_relative(c,
                 wc.x - get_actual_x(c) - 2 * left_width(c),
                 wc.y - get_actual_y(c) - 2 * top_height(c));


### PR DESCRIPTION
There was a bug where clients would send configure notify
requests when they were fullscreen, causing the client geometry
to refresh and forcing them to follow the display boundaries,
even with edge_lock set.

This change nullifies configure notify requests for clients which are
fullscreened.