### PR TITLE
fix formatting typo on berryc man page

### DIFF
--- a/berryc.1
+++ b/berryc.1
@@ -149,7 +149,7 @@ name the ith desktop d_name (Used with _NET_DESKTOP_NAMES)
 .TP
 \fB[manage|unmanage]\fR [Dialog|Toolbar|Menu|Splash|Utility]\fR
 Manage, or unmanage, windows of type Dialog, Toolbar, Menu, Splash, or Utility.
-By default, Only Toolbars and Splashes are not managed. 
+By default, Only Toolbars and Splashes are not managed.
 .
 .TP
 \fBedge_gap\fR \fBtop\fR \fBbottom\fR \fBleft\fR \fBright\fR
@@ -176,9 +176,9 @@ Set to a default value of 0.
 Useful for input lag on high refresh rate screens.
 If you experience input lag on high refresh rate screens, try a value around 15.
 .
-.tp
-\fbquit\fr
-stop the program
+.TP
+\fBquit\fR \fB\fR
+stop the program.
 .
 .TP
 \fBedge_lock\fR \fBtrue/false\fR


### PR DESCRIPTION
berryc.1 had the quit command on the same line as the explanation for the previous command - this fixes that.