### PR TITLE
berrywm: mouse resize/move with multiple modifiers

### DIFF
--- a/client.c
+++ b/client.c
@@ -23,6 +23,7 @@ static void fn_bool(long *, bool, int, char **);
 static void fn_font(long *, bool, int, char **);
 static void fn_str(long *, bool, int, char **);
 static void fn_int_str(long *, bool, int, char **);
+static void fn_mask(long *, bool, int, char **);
 static void usage(void);
 static void version(void);
 
@@ -79,8 +80,8 @@ static const struct command command_table[] = {
     { "unmanage",               IPCUnmanage,                true,  1, fn_str     },
     { "decorate_new",           IPCDecorate,                true,  1, fn_bool    },
     { "name_desktop",           IPCNameDesktop,             false, 2, fn_int_str },
-    { "move_mask",              IPCMoveMask,                true,  1, fn_str     },
-    { "resize_mask",            IPCResizeMask,              true,  1, fn_str     },
+    { "move_mask",              IPCMoveMask,                true,  1, fn_mask    },
+    { "resize_mask",            IPCResizeMask,              true,  1, fn_mask    },
     { "pointer_interval",       IPCPointerInterval,         true,  1, fn_int     },
     { "focus_follows_pointer",  IPCFocusFollowsPointer,     true,  1, fn_bool    },
     { "warp_pointer",           IPCWarpPointer,             true,  1, fn_bool    },
@@ -173,6 +174,26 @@ fn_int_str(long *data, bool b, int i, char **argv)
 
     XFree(text_prop.value);
     free(list);
+}
+
+static void
+fn_mask(long *data, bool b, int i, char **argv)
+{
+    UNUSED(b);
+    data[i+b] = 0;
+    char * mask_str = strtok( argv[i-1] , "|");
+
+    while( mask_str != NULL ) {
+        if( ! strcmp(mask_str,"shift") ) data[i+b] = data[i+b]|ShiftMask;
+        else if( !strcmp(mask_str,"lock") ) data[i+b] = data[i+b]|LockMask;
+        else if( !strcmp(mask_str,"ctrl") ) data[i+b] = data[i+b]|ControlMask;
+        else if( !strcmp(mask_str,"mod1") ) data[i+b] = data[i+b]|Mod1Mask;
+        else if( !strcmp(mask_str,"mod2") ) data[i+b] = data[i+b]|Mod1Mask;
+        else if( !strcmp(mask_str,"mod3") ) data[i+b] = data[i+b]|Mod2Mask;
+        else if( !strcmp(mask_str,"mod4") ) data[i+b] = data[i+b]|Mod3Mask;
+        else if( !strcmp(mask_str,"mod5") ) data[i+b] = data[i+b]|Mod4Mask;
+        mask_str = strtok(NULL, "|");
+    }
 }
 
 static void

--- a/client.c
+++ b/client.c
@@ -192,6 +192,11 @@ fn_mask(long *data, bool b, int i, char **argv)
         else if( !strcmp(mask_str,"mod3") ) data[i+b] = data[i+b]|Mod2Mask;
         else if( !strcmp(mask_str,"mod4") ) data[i+b] = data[i+b]|Mod3Mask;
         else if( !strcmp(mask_str,"mod5") ) data[i+b] = data[i+b]|Mod4Mask;
+        else {
+            printf("%s is not a valid modifier", mask_str);
+            data[i+b]=0;
+            break;
+        }
         mask_str = strtok(NULL, "|");
     }
 }

--- a/client.c
+++ b/client.c
@@ -118,10 +118,6 @@ fn_str(long *data, bool b, int i, char **argv)
     else if (strcmp(argv[i-1], "Menu") == 0) data[i+b] = Menu;
     else if (strcmp(argv[i-1], "Splash") == 0) data[i+b] = Splash;
     else if (strcmp(argv[i-1], "Utility") == 0) data[i+b] = Utility;
-    else if (strcmp(argv[i-1], "Mod1") == 0) data[i+b] = Mod1Mask;
-    else if (strcmp(argv[i-1], "Mod2") == 0) data[i+b] = Mod2Mask;
-    else if (strcmp(argv[i-1], "Mod3") == 0) data[i+b] = Mod3Mask;
-    else if (strcmp(argv[i-1], "Mod4") == 0) data[i+b] = Mod4Mask;
 }
 
 /* This function works by setting a new atom globally on the root

--- a/wm.c
+++ b/wm.c
@@ -1160,12 +1160,12 @@ ipc_config(long *d)
             break;
         case IPCMoveMask:
             ungrab_buttons();
-            conf.move_mask = d[2];
+            conf.move_mask = (d[2] == 0) ? conf.move_mask : d[2];
             grab_buttons();
             break;
         case IPCResizeMask:
             ungrab_buttons();
-            conf.resize_mask = d[2];
+            conf.resize_mask = (d[2] == 0) ? conf.resize_mask : d[2];
             grab_buttons();
             break;
         case IPCPointerInterval:


### PR DESCRIPTION
Berry currently accepts only one modifier for `resize/move_mask`.
This version allows using one or more modifiers to resize/move
Allowing a wide selection of key combinations.

```                                                                              
Modifiers:                                                                       
shift, lock, ctrl, mod1, mod2, mod3, mod4, mod5                                  
                                                                                 
Examples:                                                                        
berryc resize_mask "mod1"             --> alt (default)                          
berryc resize_mask "shift|mod1"       --> shift + alt                            
berryc resize_mask "ctrl|shift|mod1"  --> ctrl + shift + alt                     
                                                                                 
berryc move_mask "mod4"               --> super (default)                        
berryc move_mask "shift|mod4"         --> shift + super                          
```   