### PR TITLE
Fix Makefile to be make verbose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,19 +22,19 @@ all:	${berry} ${berryc}
 
 ${berry}:	$Outils.o $Owm.o
 	@echo "Linking $@ ..."
-	@${CC} ${ldflags} -o $@ $^ ${libs}
+	${CC} ${ldflags} -o $@ $^ ${libs}
 
 ${berryc}:	$Oclient.o
 	@echo "Linking $@ ..."
-	@${CC} ${ldflags} -o $@ $^ ${libs}
+	${CC} ${ldflags} -o $@ $^ ${libs}
 
 $O%.o:	%.c
 	@echo "    Compiling $< ..."
-	@${CC} ${cflags} -MMD -MT "$(<:.c=.s) $@" -o $@ -c $<
+	${CC} ${cflags} -MMD -MT "$(<:.c=.s) $@" -o $@ -c $<
 
 %.s:	%.c
 	@echo "    Compiling $< to assembly ..."
-	@${CC} ${cflags} -S -o $@ -c $<
+	${CC} ${cflags} -S -o $@ -c $<
 
 ################ Installation ##########################################
 


### PR DESCRIPTION
Detailing is necessary at the moment to deal with some Flags.
In this case, the change was necessary to handle the LDFLAGS and CFLAGS flags.
[03-fix-makefile-verbose.md](https://github.com/JLErvin/berry/files/7778309/03-fix-makefile-verbose.md)