### PR TITLE
Fix memory leak in ewmh_set_desktop_names

### DIFF
--- a/wm.c
+++ b/wm.c
@@ -2298,17 +2298,15 @@ static void ewmh_set_client_list(void)
 */
 static void ewmh_set_desktop_names(void)
 {
-    char **list;
+    char** list = calloc(WORKSPACE_NUMBER, sizeof(char*));
+    for (int i = 0; i < WORKSPACE_NUMBER; i++)
+        asprintf(&list[i], "%d", i);
     XTextProperty text_prop;
-    list = malloc(sizeof(char*) * WORKSPACE_NUMBER);
-    for (int i = 0; i < WORKSPACE_NUMBER; i++) {
-        char *tmp = malloc(sizeof(char) * 2 + 1);
-        sprintf(tmp, "%d", i);
-        list[i] = tmp;
-    }
     Xutf8TextListToTextProperty(display, list, WORKSPACE_NUMBER, XUTF8StringStyle, &text_prop);
     XSetTextProperty(display, root, &text_prop, XInternAtom(display, "_NET_DESKTOP_NAMES", False));
     XFree(text_prop.value);
+    for (int i = 0; i < WORKSPACE_NUMBER; i++)
+        free(list[i]);
     free(list);
 }
 


### PR DESCRIPTION
Free members of char** list at the end of ewmh_set_desktop_names. list
contains workspace numbers in text form and only the list pointer was
freed at the end, leaking the members.

Use asprintf instead of malloc/sprintf to print the numbers. malloc was
used to allocate a fixed size 3 byte array, which could overflow if
WORKSPACE_NUMBER were to be increased to 100.

Use calloc to allocate list so that in case of asprintf failure the
members would be NULL instead of random memory contents.