### PR TITLE
ModNMask constants should match up to modN options passed to the client

### DIFF
--- a/client.c
+++ b/client.c
@@ -186,10 +186,10 @@ fn_mask(long *data, bool b, int i, char **argv)
         else if( !strcmp(mask_str,"lock") ) data[i+b] = data[i+b]|LockMask;
         else if( !strcmp(mask_str,"ctrl") ) data[i+b] = data[i+b]|ControlMask;
         else if( !strcmp(mask_str,"mod1") ) data[i+b] = data[i+b]|Mod1Mask;
-        else if( !strcmp(mask_str,"mod2") ) data[i+b] = data[i+b]|Mod1Mask;
-        else if( !strcmp(mask_str,"mod3") ) data[i+b] = data[i+b]|Mod2Mask;
-        else if( !strcmp(mask_str,"mod4") ) data[i+b] = data[i+b]|Mod3Mask;
-        else if( !strcmp(mask_str,"mod5") ) data[i+b] = data[i+b]|Mod4Mask;
+        else if( !strcmp(mask_str,"mod2") ) data[i+b] = data[i+b]|Mod2Mask;
+        else if( !strcmp(mask_str,"mod3") ) data[i+b] = data[i+b]|Mod3Mask;
+        else if( !strcmp(mask_str,"mod4") ) data[i+b] = data[i+b]|Mod4Mask;
+        else if( !strcmp(mask_str,"mod5") ) data[i+b] = data[i+b]|Mod5Mask;
         else {
             printf("%s is not a valid modifier", mask_str);
             data[i+b]=0;


### PR DESCRIPTION
Running `berryc resize_mask "shift|mod4"` does not work. When pressing Super+Shift and moving the mouse, nothing happens. However, running `berryc resize_mask "shift|mod5"` does allow Super+Shift to resize the mouse when dragging. This is because in `client.c`, the options mod1 and mod2 are mapped both to Mod1Mask and subsequent options are all also off by one (thus mod3 maps to Mod2Mask, mod4 maps to Mod3Mask, etc). This patch fixes that.