### PR TITLE
Document the correct options for cardinal_focus and what they mean

### DIFF
--- a/berryc.1
+++ b/berryc.1
@@ -71,8 +71,8 @@ Move and resize the current window to fill the left half of the screen\. Respect
 Move and resize the current window to fill the right half of the screen\. Respects TOP_GAP\.
 .
 .TP
-\fBcardinal_focus\fR \fB1, 2, 3, 4\fR
-Switch focus to the nearest window in the specified direction\.
+\fBcardinal_focus\fR \fB0, 1, 2, 3\fR
+Switch focus to the nearest window in the specified direction (0=East, 1=North, 2=West, 3=South)\.
 .
 .TP
 \fBcycle_focus\fR


### PR DESCRIPTION
The documentation for `berryc cardinal_focus` is inaccurate and also incomplete. The options the command accepts are actually `0, 1, 2, 3` (not as documented `1, 2, 3, 4`) and there is also no explanation in the man file of what those options mean. This patch changes the documentation to match the working options and explains what they do.