### PR TITLE
Persist decorations on workspace send

### DIFF
--- a/wm.c
+++ b/wm.c
@@ -424,9 +424,6 @@ client_delete(struct client *c)
         LOGP("Deleting client on workspace %d", ws);
     }
 
-    /* Prevent BadDrawable error which sometimes occurs as a window is closed */
-    client_decorations_destroy(c);
-
     /* Delete in the stack */
     if (c_list[ws] == c) {
         c_list[ws] = c_list[ws]->next;
@@ -834,7 +831,7 @@ handle_unmap_notify(XEvent *e)
         LOGN("Client found while unmapping, focusing next client");
         focus_best(c);
         if (c->decorated)
-            XDestroyWindow(display, c->dec);
+            client_decorations_destroy(c);
         client_delete(c);
         free(c);
         client_raise(f_client);


### PR DESCRIPTION
This change addresses https://github.com/JLErvin/berry/issues/143, (re)adding support for persisting decorations when windows are sent between workspaces. Although this was included previously, it was removed (unintentionally) as a consequence of https://github.com/JLErvin/berry/pull/136.

This change is implemented by moving the `client_decorations_destroy` call from `client_delete` to `handle_unmap_notify`. #136 was implemented to avoid `BadDrawable` errors when a window is closed, so we can move the logic there and allow the `client_delete` code to persist the decoration state.