### PR TITLE
Avoid creation of zombie process by load_config

### DIFF
--- a/wm.c
+++ b/wm.c
@@ -4,6 +4,7 @@
 #include "config.h"
 
 #include <limits.h>
+#include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdint.h>
@@ -2536,8 +2537,10 @@ main(int argc, char *argv[])
     LOGN("Successfully opened display");
 
     setup();
-    if (conf_found)
+    if (conf_found) {
+        signal(SIGCHLD, SIG_IGN);
         load_config(conf_path);
+    }
     run();
     close_wm();
     free(font_name);


### PR DESCRIPTION
Previously, a zombie process was created when the process forked in load_config terminates because the parent does not call wait or waitpid. It is unreasonable to wait for the child because a user may exec their autostart script into a long-running process. Instead, the parent now simply ignores SIGCHLD which allows the child to be reaped immediately upon termination.