### PR TITLE
Added window_hide command

### DIFF
--- a/client.c
+++ b/client.c
@@ -45,6 +45,7 @@ static const struct command command_table[] = {
     { "window_resize",          IPCWindowResizeRelative,    false, 2, fn_int     },
     { "window_resize_absolute", IPCWindowResizeAbsolute,    false, 2, fn_int     },
     { "window_raise",           IPCWindowRaise,             false, 0, NULL       },
+    { "window_hide",           IPCWindowHide,             false, 0, NULL       },
     { "window_monocle",         IPCWindowMonocle,           false, 0, NULL       },
     { "window_close",           IPCWindowClose,             false, 0, NULL       },
     { "window_center",          IPCWindowCenter,            false, 0, NULL       },

--- a/ipc.h
+++ b/ipc.h
@@ -11,6 +11,7 @@ enum IPCCommand
     IPCWindowMoveAbsolute,
     IPCWindowMonocle,
     IPCWindowRaise,
+    IPCWindowHide,
     IPCWindowResizeRelative,
     IPCWindowResizeAbsolute,
     IPCWindowToggleDecorations,


### PR DESCRIPTION
I've added a command for minimizing windows without closing them outright. This is only useful if you have a dock installed.
The only bug I know of is that all hidden windows will become un-hidden if you click on an unfocused window's header. This might be the affect of [fix_ws_focusing_issue](https://github.com/JLErvin/berry/tree/fix_ws_focusing_issue).