### PR TITLE
Add IPCPlace functionality

### DIFF
--- a/client.c
+++ b/client.c
@@ -89,6 +89,7 @@ static const struct command command_table[] = {
     { "pointer_interval",       IPCPointerInterval,         true,  1, fn_int     },
     { "focus_follows_pointer",  IPCFocusFollowsPointer,     true,  1, fn_bool    },
     { "warp_pointer",           IPCWarpPointer,             true,  1, fn_bool    },
+    { "place",                  IPCPlace,                   false, 0, NULL       },
 };
 
 static void

--- a/ipc.h
+++ b/ipc.h
@@ -58,6 +58,7 @@ enum IPCCommand
     IPCPointerInterval,
     IPCFocusFollowsPointer,
     IPCWarpPointer,
+    IPCPlace,
     IPCLast
 };
 

--- a/wm.c
+++ b/wm.c
@@ -122,6 +122,7 @@ static void ipc_snap_right(long *d);
 static void ipc_cardinal_focus(long *d);
 static void ipc_cycle_focus(long *d);
 static void ipc_pointer_focus(long *d);
+static void ipc_place(long *d);
 static void ipc_config(long *d);
 static void ipc_save_monitor(long *d);
 static void ipc_set_font(long *d);
@@ -197,6 +198,7 @@ static const ipc_event_handler_t ipc_handler [IPCLast] = {
     [IPCSaveMonitor]              = ipc_save_monitor,
     [IPCSetFont]                  = ipc_set_font,
     [IPCEdgeGap]                  = ipc_edge_gap,
+    [IPCPlace]                    = ipc_place,
     [IPCConfig]                   = ipc_config
 };
 
@@ -1088,6 +1090,13 @@ ipc_pointer_focus(long *d)
             switch_ws(c->ws);
         }
     }
+}
+
+static void
+ipc_place(long *d)
+{
+    UNUSED(d);
+    client_place(f_client);
 }
 
 static void


### PR DESCRIPTION
Currently, `client_place` is used when spawning new windows to invoke the _smart place_ functionality - a fast, dynamic programming algorithm that places windows in such a manner that they don't overlap with existing windows. However, there is no way to invoke this after a way window has been spawned.

This PR adds the ability to manually call `client_place` on the active window from the client.