### PR TITLE
Added support for _NET_WM_STATE_BELOW and window_below command

### DIFF
--- a/berryc.1
+++ b/berryc.1
@@ -47,6 +47,10 @@ Closes the current window, in turn terminating the associated process
 Centers the current window.
 .
 .TP
+\fBwindow_below\fR
+Toggles "Always Below" on the current window, preventing it from rising to the top when activated.
+.
+.TP
 \fBswitch_workspace\fR \fBi\fR
 Switch to the given workspace, showing all windows on the new workspace and hiding all windows not on the given workspace
 .

--- a/client.c
+++ b/client.c
@@ -48,6 +48,7 @@ static const struct command command_table[] = {
     { "window_monocle",         IPCWindowMonocle,           false, 0, NULL       },
     { "window_close",           IPCWindowClose,             false, 0, NULL       },
     { "window_center",          IPCWindowCenter,            false, 0, NULL       },
+    { "window_below",           IPCBelow,                   false, 0, NULL       },
     { "focus_color",            IPCFocusColor,              true,  1, fn_hex     },
     { "unfocus_color",          IPCUnfocusColor,            true,  1, fn_hex     },
     { "inner_focus_color",      IPCInnerFocusColor,         true,  1, fn_hex     },

--- a/ipc.h
+++ b/ipc.h
@@ -58,6 +58,7 @@ enum IPCCommand
     IPCPointerInterval,
     IPCFocusFollowsPointer,
     IPCWarpPointer,
+    IPCBelow,
     IPCLast
 };
 

--- a/types.h
+++ b/types.h
@@ -16,7 +16,7 @@ struct client_geom {
 struct client {
     Window window, dec;
     int ws, x_hide;
-    bool decorated, hidden, fullscreen, mono, was_fs;
+    bool decorated, hidden, fullscreen, mono, was_fs, below;
     struct client_geom geom;
     struct client_geom prev;
     struct client *next, *f_next;
@@ -42,6 +42,7 @@ enum atoms_net {
     NetCurrentDesktop,
     NetClientList,
     NetWMStateFullscreen,
+    NetWMStateBelow,
     NetWMCheck,
     NetWMState,
     NetWMName,

--- a/types.h
+++ b/types.h
@@ -16,7 +16,7 @@ struct client_geom {
 struct client {
     Window window, dec;
     int ws, x_hide;
-    bool decorated, hidden, fullscreen, mono, was_fs, below;
+    bool decorated, hidden, fullscreen, mono, was_fs;
     struct client_geom geom;
     struct client_geom prev;
     struct client *next, *f_next;

--- a/wm.c
+++ b/wm.c
@@ -1076,8 +1076,7 @@ ipc_below(long *d)
     if (f_client == NULL)
         return;
 
-    f_client->below = !f_client->below;
-    ewmh_set_below(f_client, f_client->below);
+    ewmh_set_below(f_client, !client_window_is_below(f_client));
 }
 
 static void
@@ -1395,7 +1394,6 @@ manage_new_window(Window w, XWindowAttributes *wa)
     c->fullscreen = false;
     c->mono = false;
     c->was_fs = false;
-    c->below = client_window_is_below(c);
 
     XSetWindowBorderWidth(display, c->window, 0);
 
@@ -1548,6 +1546,7 @@ client_window_is_below(struct client *c)
             }
         }
     }
+    XFree(prop_ret);
     return false;
 }
 
@@ -1563,7 +1562,7 @@ client_move_to_front(struct client *c)
 
 
     /* If the Client is set to be always below */
-    if (c->below || client_window_is_below(c))
+    if (client_window_is_below(c))
         return;
 
     /* If the Client is at the front of the list, ignore command */
@@ -1708,7 +1707,7 @@ client_raise(struct client *c)
     if (c != NULL) {
 
         /* If the Client is set to be always below */
-        if (c->below || client_window_is_below(c))
+        if (client_window_is_below(c))
             return;
 
         if (!c->decorated) {


### PR DESCRIPTION
Solved the issue I [mentioned](https://github.com/JLErvin/berry/issues/214). WM now reads `_NET_WM_STATE_BELOW` when managing window and saves it in `client.below`. Raising the window is now made with the respect to `_NET_WM_STATE_BELOW` and `client.below`. Always below state can now be toggled with `berryc window_below` command. I had to rearrange             `client_manage_focus` and `switch_ws` in `ipc_pointer_focus` because `swith_ws` was focusing top most window after handling the switch and it moved the focus away from the bottom window that you're trying to point on.