### PR TITLE
Fixed absence of smart_place handling

### DIFF
--- a/wm.c
+++ b/wm.c
@@ -1187,6 +1187,8 @@ ipc_config(long *d)
         case IPCWarpPointer:
             conf.warp_pointer = d[2];
             break;
+        case IPCSmartPlace:
+            conf.smart_place = d[2];
         default:
             break;
     }


### PR DESCRIPTION
I noticed that `smart_place false` was not working neither in autostart and berryc directly. It turned out that `wm.c` had no handling for it, so I added it.