### PR TITLE
Center the client if it's not smart placed

### DIFF
--- a/wm.c
+++ b/wm.c
@@ -1656,6 +1656,8 @@ client_place(struct client *c)
             count = 0;
         }
     }
+    // Center the client if there is no space for it
+    client_center(c);
 }
 
 static void


### PR DESCRIPTION
It was really annoying when new windows appeared on top left corner when there is no space for them to be smart placed, so I made them centered. I've seen such suggestion in [this issue](https://github.com/JLErvin/berry/issues/201) when I tried to find the solution, so I think this is the most obvious behavior compared to the previous one.