### PR TITLE
Added window_kill feature

### DIFF
--- a/berryc.1
+++ b/berryc.1
@@ -43,6 +43,10 @@ Monocles the curent window, respecting values of TOP_GAP
 Closes the current window, in turn terminating the associated process
 .
 .TP
+\fBwindow_kill\fR
+Kills the current window, forcefully terminating the associated process
+.
+.TP
 \fBwindow_center\fR
 Centers the current window.
 .

--- a/client.c
+++ b/client.c
@@ -47,6 +47,7 @@ static const struct command command_table[] = {
     { "window_raise",           IPCWindowRaise,             false, 0, NULL       },
     { "window_monocle",         IPCWindowMonocle,           false, 0, NULL       },
     { "window_close",           IPCWindowClose,             false, 0, NULL       },
+    { "window_kill",            IPCWindowKill,              false, 0, NULL       },
     { "window_center",          IPCWindowCenter,            false, 0, NULL       },
     { "focus_color",            IPCFocusColor,              true,  1, fn_hex     },
     { "unfocus_color",          IPCUnfocusColor,            true,  1, fn_hex     },

--- a/ipc.h
+++ b/ipc.h
@@ -36,6 +36,7 @@ enum IPCCommand
     IPCCardinalFocus,
     IPCCycleFocus,
     IPCWindowClose,
+    IPCWindowKill,
     IPCWindowCenter,
     IPCPointerFocus,
     IPCTopGap,


### PR DESCRIPTION
I encountered many situations where such functionality would be useful. I spied it out of worm wm, and I really liked it. It is not always enough to simply close the client, sometimes you just have to _kill_ it. It is very convenient to do this using wm, because it can point to the active client and just call `XKillClient`. 

I'm not sure if it was a good decision to make a separate `client_kill` function that has only one call in it, but I made it to maintain homogeneity.

And sorry for the spam. I hope I haven't tired you with all my requests. I really loved what you created, so I wanted to help as much as possible and make it better.