### PR TITLE
Fixed client raise with fullscreen windows

### DIFF
--- a/wm.c
+++ b/wm.c
@@ -672,10 +672,7 @@ handle_button_press(XEvent *e)
     c = get_client_from_window(bev->window);
     if (c == NULL)
         return;
-    if (c != f_client) {
-        switch_ws(c->ws);
-        client_manage_focus(c);
-    }
+    client_manage_focus(c);
     // If it's not window movement or resize then process focus on click
     state = mod_clean(bev->state);
     if (conf.focus_on_click && bev->button == (unsigned)conf.focus_button && state != (unsigned)conf.move_mask && state != (unsigned)conf.resize_mask && bev->window != c->dec)


### PR DESCRIPTION
I was having issues when cycling through windows on a workspace with fullscreen windows. 

Looks like `XRestackWindows` works unreliably when `_NET_WM_STATE_FULLSCREEN` window is present. In this case, all the nonfullscreen windows rose in the same order they were in, but the focused window did not rise to the top.  I've seen that `XRestackWindows` has a lot of limitations, so maybe that's one of it. 

I've tried a couple solutions and after some thoughts found a simple one. I just used two `XRaiseWindow` for decoration and main window. It seems deterministic and don't cause any issues. LLM tells me that it should raise windows in order, even if X actually does it asynchronously after both calls. 

I'm not sure what that `XRestackWindows` was for, if we only need to raise a single window with its decoration. Even if the window has children, won't they go up with the parent window?