### PR TITLE
Fixed fullscreen and fullscreen_state mismatch

### DIFF
--- a/types.h
+++ b/types.h
@@ -16,7 +16,7 @@ struct client_geom {
 struct client {
     Window window, dec;
     int ws, x_hide;
-    bool decorated, hidden, fullscreen, mono, was_fs;
+    bool decorated, hidden, fullscreen, mono, was_dec;
     struct client_geom geom;
     struct client_geom prev;
     struct client *next, *f_next;


### PR DESCRIPTION
When setting up berrywm initially I encountered an issue that I saw [here](https://github.com/JLErvin/berry/issues/206). I thought that it was just a simple mismatch of calls, but it turned out to be a bug. 

`max` was cast to void with `UNUSED(max)` in the first place. I'm not sure if it affected the actual variable, but I removed it.

In one of the branches of the if statement it was not using `max`, but `conf.fs_max` instead, so the behavior was unpredictable. I was about to remove `conf.fs_max` and `FULLSCREEN_MAX`, since they were not used anymore, but I left it in place and added a feature to disable `max` on demand with those variables (like it was intended probably).

I also renamed `was_fs` to `was_dec`,  because that name confused me when I was trying to figure out what this variable states. It's telling that the window was decorated and we need to set the decoration back.

And deleted the `conf.fs_remove_dec` check on restoring decorations, since it's already covered with `was_dec` check.

Now `fullscreen` and `fullscreen_state` work as stated in docs.