### PR TITLE
Fixed redundant switch_ws and client check that caused focus mismatch

### DIFF
--- a/wm.c
+++ b/wm.c
@@ -673,10 +673,7 @@ handle_button_press(XEvent *e)
     c = get_client_from_window(bev->window);
     if (c == NULL)
         return;
-    if (c != f_client) {
-        switch_ws(c->ws);
-        client_manage_focus(c);
-    }
+    client_manage_focus(c);
     // If it's not window movement or resize then process focus on click
     state = mod_clean(bev->state);
     if (conf.focus_on_click && bev->button == (unsigned)conf.focus_button && state != (unsigned)conf.move_mask && state != (unsigned)conf.resize_mask && bev->window != c->dec)

--- a/wm.c
+++ b/wm.c
@@ -673,18 +673,23 @@ handle_button_press(XEvent *e)
     c = get_client_from_window(bev->window);
     if (c == NULL)
         return;
-    client_manage_focus(c);
-    // If it's not window movement or resize then process focus on click
     state = mod_clean(bev->state);
-    if (conf.focus_on_click && bev->button == (unsigned)conf.focus_button && state != (unsigned)conf.move_mask && state != (unsigned)conf.resize_mask && bev->window != c->dec)
+    // If it's not window movement or resize then process focus on click
+    if (state != (unsigned)conf.move_mask && state != (unsigned)conf.resize_mask && bev->window != c->dec)
     {
-        LOGN("Handling focus on click");
-        // Ungrab buttons, propagate event to the window, and regrab
-        window_ungrab_buttons(bev->window);
-        XAllowEvents(display, ReplayPointer, CurrentTime);
-        window_grab_buttons(bev->window);
-        return;
+        if (conf.focus_on_click && bev->button == (unsigned)conf.focus_button)
+        {
+            client_manage_focus(c);
+            LOGN("Handling focus on click");
+            // Ungrab buttons, propagate event to the window, and regrab
+            window_ungrab_buttons(bev->window);
+            XAllowEvents(display, ReplayPointer, CurrentTime);
+            window_grab_buttons(bev->window);
+        }
+        return; // Not move, not resize, not decoration, disabled focus_on_click
     }
+    // Manage focus on move, resize ro a decoration click
+    client_manage_focus(c);
     // Otherwise process window movement or resize
     ocx = c->geom.x;
     ocy = c->geom.y;

--- a/wm.c
+++ b/wm.c
@@ -1351,6 +1351,9 @@ load_config(char *conf_path)
 static void
 client_manage_focus(struct client *c)
 {
+    if (c == f_client)
+        return;
+
     if (c != NULL && f_client != NULL) {
         client_set_color(f_client, conf.iu_color, conf.bu_color);
         draw_text(f_client, false);


### PR DESCRIPTION
I noticed some instabilities in internal mouse focus that I introduces earlier. I removed an additional check before changing focus and redundant `switch_ws()` which is already included in the `client_manage_focus()`. I'm not sure what caused those instabilities, because I haven't noticed any pattern, focus may or may not switch to the window you click on. It may be caused by async nature of X. But with that fix everything works fine!