### PR TITLE
Added always above functionality

### DIFF
--- a/berryc.1
+++ b/berryc.1
@@ -55,6 +55,10 @@ Centers the current window.
 Toggles "Always Below" on the current window, preventing it from rising to the top when activated.
 .
 .TP
+\fBwindow_above\fR
+Toggles "Always Above" on the current window, preventing other windows from rising above it.
+.
+.TP
 \fBswitch_workspace\fR \fBi\fR
 Switch to the given workspace, showing all windows on the new workspace and hiding all windows not on the given workspace
 .

--- a/client.c
+++ b/client.c
@@ -50,6 +50,7 @@ static const struct command command_table[] = {
     { "window_kill",            IPCWindowKill,              false, 0, NULL       },
     { "window_center",          IPCWindowCenter,            false, 0, NULL       },
     { "window_below",           IPCBelow,                   false, 0, NULL       },
+    { "window_above",           IPCAbove,                   false, 0, NULL       },
     { "focus_color",            IPCFocusColor,              true,  1, fn_hex     },
     { "unfocus_color",          IPCUnfocusColor,            true,  1, fn_hex     },
     { "inner_focus_color",      IPCInnerFocusColor,         true,  1, fn_hex     },

--- a/ipc.h
+++ b/ipc.h
@@ -62,6 +62,7 @@ enum IPCCommand
     IPCFocusOnClick,
     IPCFocusButton,
     IPCBelow,
+    IPCAbove,
     IPCLast
 };
 

--- a/types.h
+++ b/types.h
@@ -43,6 +43,7 @@ enum atoms_net {
     NetClientList,
     NetWMStateFullscreen,
     NetWMStateBelow,
+    NetWMStateAbove,
     NetWMCheck,
     NetWMState,
     NetWMName,

--- a/wm.c
+++ b/wm.c
@@ -65,7 +65,6 @@ static void client_hide(struct client *c);
 static void client_manage_focus(struct client *c);
 static void client_move_absolute(struct client *c, int x, int y);
 static void client_move_relative(struct client *c, int x, int y);
-static void client_move_to_front(struct client *c);
 static void client_monocle(struct client *c);
 static void client_place(struct client *c);
 static void client_raise(struct client *c);
@@ -152,6 +151,7 @@ static void run(void);
 static bool safe_to_focus(int ws);
 static void setup(void);
 static void switch_ws(int ws);
+static void restack_ws(int ws);
 static void warp_pointer(struct client *c);
 static void usage(void);
 static void version(void);
@@ -1349,14 +1349,15 @@ load_config(char *conf_path)
 static void
 client_manage_focus(struct client *c)
 {
+    /* Manage previous focus */
     if (c != NULL && f_client != NULL) {
         client_set_color(f_client, conf.iu_color, conf.bu_color);
         draw_text(f_client, false);
         manage_xsend_icccm(c, wm_atom[WMTakeFocus]);
     }
 
+    /* Manage new focus */
     if (c != NULL) {
-        client_move_to_front(c);
         client_set_color(c, conf.if_color, conf.bf_color);
         draw_text(c, true);
         client_raise(c);
@@ -1612,36 +1613,6 @@ client_window_is_below(struct client *c)
 }
 
 static void
-client_move_to_front(struct client *c)
-{
-    int ws;
-    ws = c->ws;
-
-    /* If we didn't find the client */
-    if (ws == -1)
-        return;
-
-
-    /* If the Client is set to be always below */
-    if (client_window_is_below(c))
-        return;
-
-    /* If the Client is at the front of the list, ignore command */
-    if (c_list[ws] == c || c_list[ws]->next == NULL)
-        return;
-
-    struct client *tmp;
-    for (tmp = c_list[ws]; tmp->next != NULL; tmp = tmp->next)
-        if (tmp->next == c)
-            break;
-
-    if (tmp && tmp->next)
-        tmp->next = tmp->next->next; /* remove the Client from the list */
-    c->next = c_list[ws]; /* add the client to the front of the list */
-    c_list[ws] = c;
-}
-
-static void
 client_monocle(struct client *c)
 {
     int mon;
@@ -1765,38 +1736,65 @@ client_place(struct client *c)
 }
 
 static void
+restack_ws(int ws)
+{
+    /* Active clients count on the current workspace*/
+    int count, i;
+    count = 0;
+    for (struct client *tmp = c_list[ws]; tmp != NULL; tmp = tmp->next) {
+        if (tmp->decorated)
+            count++;
+        count++;
+    }
+
+    if (count == 0)
+        return;
+
+    Window wins[count];
+
+    i = 0;
+    for (struct client *tmp = c_list[ws]; tmp != NULL; tmp = tmp->next) {
+        LOGP("Client: %d", tmp);
+        wins[i++] = tmp->window;
+        if (tmp->decorated)
+            wins[i++] = tmp->dec;
+    }
+    XRestackWindows(display, wins, count);
+}
+
+static void
 client_raise(struct client *c)
 {
-    if (c != NULL) {
+    if (c == NULL)
+        return;
 
-        /* If the Client is set to be always below */
-        if (client_window_is_below(c))
-            return;
+    int ws;
+    ws = c->ws;
 
-        if (!c->decorated) {
-            XRaiseWindow(display, c->window);
-        } else {
-            // how may active clients are there on our workspace
-            int count, i;
-            count = 0;
-            for (struct client *tmp = c_list[c->ws]; tmp != NULL; tmp = tmp->next) {
-                count++;
-            }
+    /* Ignore if we didn't find the client */
+    if (ws == -1)
+        return;
 
-            if (count == 0)
-                return;
+    /* Ignore if the Client is set to be always below */
+    if (client_window_is_below(c))
+        return;
 
-            Window wins[count*2];
+    /* If the Client is not at the front of the list */
+    if (c_list[ws] != c && c_list[ws]->next != NULL) {
+        /* Move the client to the front of the client list */
+        struct client *tmp;
+        for (tmp = c_list[ws]; tmp->next != NULL; tmp = tmp->next)
+            if (tmp->next == c)
+                break;
 
-            i = 0;
-            for (struct client *tmp = c_list[c->ws]; tmp != NULL; tmp = tmp->next) {
-                wins[i] = tmp->window;
-                wins[i+1] = tmp->dec;
-                i += 2;
-            }
-            XRestackWindows(display, wins, count*2);
-        }
+        if (tmp && tmp->next)
+            tmp->next = tmp->next->next; /* Remove the Client from the list */
+        c->next = c_list[ws]; /* Add the client to the front of the list */
+        c_list[ws] = c;
     }
+
+    /* Restack windows on screen even if the list was not changed to ensure actual wm state */
+    restack_ws(ws);
 }
 
 static void monitors_setup(void)
@@ -2237,27 +2235,10 @@ switch_ws(int ws)
                 LOGN("Hiding client...");
             }
         } else if (i == ws) {
-            int count, j;
-            count = 0;
-
-            // how many active clients are on the current workspace
             for (struct client *tmp = c_list[i]; tmp != NULL; tmp = tmp->next) {
-                count++;
                 client_show(tmp);
             }
-
-            if (count != 0) {
-                Window wins[count*2];
-                j = 0;
-
-                for (struct client *tmp = c_list[i]; tmp != NULL; tmp = tmp->next) {
-                    wins[j] = tmp->window;
-                    wins[j+1] = tmp->dec;
-                    j += 2;
-                }
-
-                XRestackWindows(display, wins, count * 2);
-            }
+            restack_ws(ws);
         }
     }
     curr_ws = ws;

--- a/wm.c
+++ b/wm.c
@@ -1837,8 +1837,10 @@ client_raise(struct client *c)
         /* Remove the Client from the list */
         if (parent && parent->next)
             parent->next = parent->next->next;
-        else
+        else if (c == c_list[ws])
             c_list[ws] = c->next;
+        else
+            return;
 
         if (client_window_is_above(c) || !last_above){
             /* Add the Client to the front of the list */

--- a/wm.c
+++ b/wm.c
@@ -1941,6 +1941,7 @@ refresh_config(void)
                 client_show(tmp);
             }
         }
+        restack_ws(i);
     }
 }
 

--- a/wm.c
+++ b/wm.c
@@ -82,6 +82,7 @@ static void client_snap_right(struct client *c);
 static void client_toggle_decorations(struct client *c);
 static void client_set_status(struct client *c);
 static bool client_window_is_below(struct client *c);
+static bool client_window_is_above(struct client *c);
 
 /* EWMH functions */
 static void ewmh_set_fullscreen(struct client *c, bool fullscreen);
@@ -93,6 +94,7 @@ static void ewmh_set_client_list(void);
 static void ewmh_set_desktop_names(void);
 static void ewmh_set_active_desktop(int ws);
 static void ewmh_set_below(struct client *c, bool below);
+static void ewmh_set_above(struct client *c, bool above);
 
 /* Event handlers */
 static void handle_client_message(XEvent *e);
@@ -126,6 +128,7 @@ static void ipc_snap_right(long *d);
 static void ipc_cardinal_focus(long *d);
 static void ipc_cycle_focus(long *d);
 static void ipc_below(long *d);
+static void ipc_above(long *d);
 static void ipc_pointer_focus(long *d);
 static void ipc_config(long *d);
 static void ipc_save_monitor(long *d);
@@ -197,6 +200,7 @@ static const ipc_event_handler_t ipc_handler [IPCLast] = {
     [IPCSwitchWorkspace]          = ipc_switch_ws,
     [IPCSendWorkspace]            = ipc_send_to_ws,
     [IPCBelow]                    = ipc_below,
+    [IPCAbove]                    = ipc_above,
     [IPCFullscreen]               = ipc_fullscreen,
     [IPCFullscreenState]          = ipc_fullscreen_state,
     [IPCSnapLeft]                 = ipc_snap_left,
@@ -1115,6 +1119,17 @@ ipc_below(long *d)
 }
 
 static void
+ipc_above(long *d)
+{
+    UNUSED(d);
+    if (f_client == NULL)
+        return;
+    
+    ewmh_set_above(f_client, !client_window_is_above(f_client));
+    client_raise(f_client);
+}
+
+static void
 ipc_pointer_focus(long *d)
 {
     UNUSED(d);
@@ -1591,7 +1606,7 @@ client_move_relative(struct client *c, int x, int y)
 static bool
 client_window_is_below(struct client *c)
 {
-    Atom prop, da;
+    Atom da;
     unsigned char *prop_ret = NULL;
     int di;
     unsigned long dl, dn;
@@ -1603,6 +1618,30 @@ client_window_is_below(struct client *c)
         Atom *states = (Atom *)prop_ret;
         for (unsigned long i = 0; i < dn; i++) {
             if (states[i] == net_atom[NetWMStateBelow]) {
+                XFree(prop_ret);
+                return true;
+            }
+        }
+    }
+    XFree(prop_ret);
+    return false;
+}
+
+static bool
+client_window_is_above(struct client *c)
+{
+    Atom da;
+    unsigned char *prop_ret = NULL;
+    int di;
+    unsigned long dl, dn;
+
+    if (XGetWindowProperty(display, c->window, net_atom[NetWMState], 0,
+                sizeof (Atom), False, XA_ATOM, &da, &di, &dn, &dl,
+                &prop_ret) == Success)
+    {
+        Atom *states = (Atom *)prop_ret;
+        for (unsigned long i = 0; i < dn; i++) {
+            if (states[i] == net_atom[NetWMStateAbove]) {
                 XFree(prop_ret);
                 return true;
             }
@@ -1738,6 +1777,7 @@ client_place(struct client *c)
 static void
 restack_ws(int ws)
 {
+    LOGN("Restacking...");
     /* Active clients count on the current workspace*/
     int count, i;
     count = 0;
@@ -1747,7 +1787,7 @@ restack_ws(int ws)
         count++;
     }
 
-    if (count == 0)
+    if (count <= 1)
         return;
 
     Window wins[count];
@@ -1764,6 +1804,7 @@ restack_ws(int ws)
 static void
 client_raise(struct client *c)
 {
+    LOGN("Raising Client...");
     if (c == NULL)
         return;
 
@@ -1778,18 +1819,36 @@ client_raise(struct client *c)
     if (client_window_is_below(c))
         return;
 
-    /* If the Client is not at the front of the list */
-    if (c_list[ws] != c && c_list[ws]->next != NULL) {
-        /* Move the client to the front of the client list */
-        struct client *tmp;
-        for (tmp = c_list[ws]; tmp->next != NULL; tmp = tmp->next)
-            if (tmp->next == c)
-                break;
+    /* If Workspace has more than a single window */
+    if (c_list[ws]->next != NULL) {
 
-        if (tmp && tmp->next)
-            tmp->next = tmp->next->next; /* Remove the Client from the list */
-        c->next = c_list[ws]; /* Add the client to the front of the list */
-        c_list[ws] = c;
+        /* Find the Client in the stack */
+        struct client *pointer, *parent, *last_above;
+        parent = NULL;
+        last_above = NULL;
+        for (pointer = c_list[ws]; pointer != NULL; pointer = pointer->next){
+            if (pointer->next == c)
+                parent = pointer;
+            if (client_window_is_above(pointer))
+                last_above = pointer;
+            else if (parent) break;
+        }
+
+        /* Remove the Client from the list */
+        if (parent && parent->next)
+            parent->next = parent->next->next;
+        else
+            c_list[ws] = c->next;
+
+        if (client_window_is_above(c) || !last_above){
+            /* Add the Client to the front of the list */
+            c->next = c_list[ws];
+            c_list[ws] = c;
+        } else {
+            /* Add the Client after the last above window */
+            c->next = last_above->next;
+            last_above->next = c;
+        }
     }
 
     /* Restack windows on screen even if the list was not changed to ensure actual wm state */
@@ -2130,6 +2189,7 @@ setup(void)
     net_atom[NetActiveWindow]        = XInternAtom(display, "_NET_ACTIVE_WINDOW", False);
     net_atom[NetWMStateFullscreen]   = XInternAtom(display, "_NET_WM_STATE_FULLSCREEN", False);
     net_atom[NetWMStateBelow]        = XInternAtom(display, "_NET_WM_STATE_BELOW", False);
+    net_atom[NetWMStateAbove]        = XInternAtom(display, "_NET_WM_STATE_ABOVE", False);
     net_atom[NetWMMoveResize]        = XInternAtom(display, "_NET_MOVERESIZE_WINDOW", False);
     net_atom[NetWMCheck]             = XInternAtom(display, "_NET_SUPPORTING_WM_CHECK", False);
     net_atom[NetCurrentDesktop]      = XInternAtom(display, "_NET_CURRENT_DESKTOP", False);
@@ -2364,6 +2424,13 @@ ewmh_set_below(struct client *c, bool below)
 {
     XChangeProperty(display, c->window, net_atom[NetWMState], XA_ATOM, 32,
             PropModeReplace, (unsigned char *)&net_atom[NetWMStateBelow], below ? 1 : 0 );
+}
+
+static void
+ewmh_set_above(struct client *c, bool above)
+{
+    XChangeProperty(display, c->window, net_atom[NetWMState], XA_ATOM, 32,
+            PropModeReplace, (unsigned char *)&net_atom[NetWMStateAbove], above ? 1 : 0);
 }
 
 static void

--- a/wm.c
+++ b/wm.c
@@ -1939,7 +1939,6 @@ refresh_config(void)
                 client_hide(tmp);
             } else {
                 client_show(tmp);
-                client_raise(tmp);
             }
         }
     }

--- a/wm.c
+++ b/wm.c
@@ -1754,7 +1754,6 @@ restack_ws(int ws)
 
     i = 0;
     for (struct client *tmp = c_list[ws]; tmp != NULL; tmp = tmp->next) {
-        LOGP("Client: %d", tmp);
         wins[i++] = tmp->window;
         if (tmp->decorated)
             wins[i++] = tmp->dec;
@@ -2201,7 +2200,6 @@ client_show(struct client *c)
     if (c->hidden) {
         LOGN("Showing client");
         client_move_absolute(c, c->x_hide, c->geom.y);
-        client_raise(c);
         c->hidden = false;
     }
 }


### PR DESCRIPTION
Added `berryc` command `window_above` that toggles always above on the focused window similar to always below. Updated `client_raise()` functionality so it respects always above windows with minimal cost. Added `client_window_is_above()` function to get current always above status of the client with EWMH. Added `ewmh_set_above()` function to change `NetWMStateAbove`.

This feature requires [another pull request](https://github.com/JLErvin/berry/pull/227) to be satisfied, because it relies on updated `client_raise()` and `restack_ws()` functionality.