### PR TITLE
Fix client unmap focus issues

### DIFF
--- a/wm.c
+++ b/wm.c
@@ -568,18 +568,6 @@ focus_next(struct client *c)
     client_manage_focus(tmp);
 }
 
-static void
-focus_best(struct client *c)
-{
-    if (c == NULL)
-        return;
-
-    if (c_list[c->ws]->next == NULL)
-        return;
-    else
-        client_manage_focus(c_list[c->ws]->next);
-}
-
 /* Returns the struct client associated with the given struct Window */
 static struct client*
 get_client_from_window(Window w)
@@ -862,12 +850,12 @@ handle_unmap_notify(XEvent *e)
 
     if (c != NULL) {
         LOGN("Client found while unmapping, focusing next client");
-        focus_best(c);
+        if (c == f_client) // Only change focus if the deleted window was the current workspace's focused window, as it's otherwise disorienting/confusing.
+            client_manage_focus(c->next); // Return focus to next window down the stack or fall back to root (null).
         if (c->decorated)
             client_decorations_destroy(c);
         client_delete(c);
         free(c);
-        client_raise(f_client);
     } else {
         /* Some applications *ahem* Spotify *ahem*, don't seem to place nicely with being deleted.
          * They close slowing, causing focusing issues with unmap requests. Check to see if the current

--- a/wm.c
+++ b/wm.c
@@ -26,7 +26,7 @@
 #include "types.h"
 #include "utils.h"
 
-static struct client *f_client = NULL; /* focused client */
+static struct client *f_client = NULL; /* focused client on current workspace */
 static struct client *c_list[WORKSPACE_NUMBER]; /* 'stack' of managed clients in drawing order */
 static struct client *f_list[WORKSPACE_NUMBER]; /* ordered lists for clients to be focused */
 static struct monitor *m_list = NULL; /* All saved monitors */
@@ -469,7 +469,7 @@ client_delete(struct client *c)
             tmp->f_next = tmp->f_next->f_next;
     }
 
-    if (c_list[ws] == NULL)
+    if (ws == curr_ws && c_list[ws] == NULL)
         f_client = NULL;
 
     client_set_wm_state(c, WithdrawnState);


### PR DESCRIPTION
* [only clear focus if the deleted window was in the current workspace](https://github.com/JLErvin/berry/commit/7441672433f58ca44c96262126f1464d89a0b336)

It used to sneakily prevent you from managing windows with berryc.

* [only change focus if the deleted window was the current workspace's focused window](https://github.com/JLErvin/berry/commit/90dce904c308861a62bf6c74b7d94ebea65b645a)

It's otherwise disorienting/confusing if a hidden window takes away focus and moves you to another workspace.

This took care of some corner cases, and there's details & repro steps in each commit description.